### PR TITLE
Fix for multiple selectors and skip html/body option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -672,14 +672,14 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string-width": {
-      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
-    },
     "string_decoder": {
       "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true
     },
     "strip-ansi": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,20 +1,22 @@
 var postcss = require("postcss");
 
-module.exports = postcss.plugin("postcss-prefixwrap", function (selector) {
-
+module.exports = postcss.plugin("postcss-prefixwrap", function (selector, options) {
   "use strict";
 
+  options = options || {};
   return function (css) {
     css.walkRules(function (rule) {
 
       // HTML and Body elements cannot be contained within our container so lets extract their styles
       // and make them the styles of our container.
-      if (rule.selector.match(/^ *(body|html).*$/)) {
+      if (!options.skipRootTags && rule.selector.match(/^ *(body|html).*$/)) {
         rule.selector = rule.selector.replace(/^ *(body|html)/, selector);
 
       // Prepend selector unless our first rule is a combination of this selector and another rule.
-      } else if (!rule.selector.match(new RegExp("^ *[^ ]*" + selector + ".*$"))) {
-        rule.selector = selector + " " + rule.selector;
+      } else if (!options.skipRootTags && !rule.selector.match(new RegExp("^ *[^ ]*" + selector + ".*$"))) {
+        rule.selector = rule.selector.split(",").map(function(sel) {
+          return selector + " " + sel.trim();
+        }).join(", ");
       }
     });
   };

--- a/test/fixtures/leave-body.css
+++ b/test/fixtures/leave-body.css
@@ -1,0 +1,9 @@
+/* Ensure is left. */
+body {
+  color: red;
+}
+
+/* Ensure is prefixed as is not first selector. */
+html {
+  color: red;
+}

--- a/test/fixtures/multiple-classes-expected.css
+++ b/test/fixtures/multiple-classes-expected.css
@@ -1,0 +1,8 @@
+/* Ensure classes are prefixed. */
+.my-container .something, .my-container .else {
+  font-size: 40px;
+}
+
+.my-container .foo, .my-container .bar {
+  font-size: 40px;
+}

--- a/test/fixtures/multiple-classes-raw.css
+++ b/test/fixtures/multiple-classes-raw.css
@@ -1,0 +1,9 @@
+/* Ensure classes are prefixed. */
+.something, .else {
+  font-size: 40px;
+}
+
+.foo,
+.bar {
+  font-size: 40px;
+}

--- a/test/mainTest.js
+++ b/test/mainTest.js
@@ -9,6 +9,7 @@ describe("PostCSS Prefix Wrap", function () {
 
   // Generate a postcss instance with our plugin enabled.
   var postCSS = postcss([prefixWrap(".my-container")]);
+  var postCSSSkip = postcss([prefixWrap(".my-container", {skipRootTags: true})]);
 
   describe("Standard Prefixing", function () {
     it("adds prefix class for tags", function () {
@@ -31,6 +32,13 @@ describe("PostCSS Prefix Wrap", function () {
         postCSS.process(fs.readFileSync(__dirname + "/fixtures/standard-classes-raw.css", "UTF-8")).css
       );
     });
+
+    it("adds prefix class for multiple classes", function () {
+      assert.equal(
+        fs.readFileSync(__dirname + "/fixtures/multiple-classes-expected.css", "UTF-8"),
+        postCSS.process(fs.readFileSync(__dirname + "/fixtures/multiple-classes-raw.css", "UTF-8")).css
+      );
+    });
   });
 
   describe("Replacement Prefixing", function () {
@@ -38,6 +46,15 @@ describe("PostCSS Prefix Wrap", function () {
       assert.equal(
         fs.readFileSync(__dirname + "/fixtures/replacement-tags-expected.css", "UTF-8"),
         postCSS.process(fs.readFileSync(__dirname + "/fixtures/replacement-tags-raw.css", "UTF-8")).css
+      );
+    });
+  });
+
+  describe("Skip html/body replacement", function () {
+    it("replaces global selectors with prefix", function () {
+      assert.equal(
+        fs.readFileSync(__dirname + "/fixtures/leave-body.css", "UTF-8"),
+        postCSSSkip.process(fs.readFileSync(__dirname + "/fixtures/leave-body.css", "UTF-8")).css
       );
     });
   });


### PR DESCRIPTION
Hello, here's PR for two issues that I've opened:

add option to disable html/body replacement (closes #2)
fix multiple selectors (closes #3)