### PR TITLE
Fix for replacing body/html in multiline css rules

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,15 +8,37 @@ module.exports = postcss.plugin("postcss-prefixwrap", function (selector, option
     css.walkRules(function (rule) {
 
       // HTML and Body elements cannot be contained within our container so lets extract their styles
-      // and make them the styles of our container.
-      if (!options.skipRootTags && rule.selector.match(/^ *(body|html).*$/)) {
-        rule.selector = rule.selector.replace(/^ *(body|html)/, selector);
 
-      // Prepend selector unless our first rule is a combination of this selector and another rule.
-      } else if (!options.skipRootTags && !rule.selector.match(new RegExp("^ *[^ ]*" + selector + ".*$"))) {
-        rule.selector = rule.selector.split(",").map(function(sel) {
-          return selector + " " + sel.trim();
-        }).join(", ");
+      // and make them the styles of our container.
+      /*      if (rule.selector.match(/^ *(body|html).*$/)) {
+       if (!options.skipRootTags) {
+       rule.selector = rule.selector.replace(/^ *(body|html)/, selector);
+       }
+       // Prepend selector unless our first rule is a combination of this selector and another rule.
+       } else*/
+      if (!rule.selector.match(new RegExp("^ *[^ ]*" + selector + ".*$"))) {
+        rule.selector = rule.selector
+          .split(",")
+          .map(function (sel) {
+            // console.log(0, sel);
+            if (sel.match(/^[\s\S]*(body|html).*$/)) {
+              // console.log(1);
+              if (options.prefixRootTags) {
+                // console.log(3);
+                return selector + " ." + sel;
+              } else {
+                // console.log(2, sel.replace(/^ *(body|html)/, selector))
+                return sel.trim().replace(/^[\s\S]*(body|html)/, selector);
+              }
+            } else {
+              // console.log(4);
+              return selector + " " + sel.trim();
+            }
+          })
+          .filter(function (sel) {
+            return sel !== null;
+          })
+          .join(", ");
       }
     });
   };

--- a/src/main.js
+++ b/src/main.js
@@ -6,32 +6,18 @@ module.exports = postcss.plugin("postcss-prefixwrap", function (selector, option
   options = options || {};
   return function (css) {
     css.walkRules(function (rule) {
-
-      // HTML and Body elements cannot be contained within our container so lets extract their styles
-
-      // and make them the styles of our container.
-      /*      if (rule.selector.match(/^ *(body|html).*$/)) {
-       if (!options.skipRootTags) {
-       rule.selector = rule.selector.replace(/^ *(body|html)/, selector);
-       }
-       // Prepend selector unless our first rule is a combination of this selector and another rule.
-       } else*/
       if (!rule.selector.match(new RegExp("^ *[^ ]*" + selector + ".*$"))) {
         rule.selector = rule.selector
           .split(",")
           .map(function (sel) {
-            // console.log(0, sel);
             if (sel.match(/^[\s\S]*(body|html).*$/)) {
-              // console.log(1);
               if (options.prefixRootTags) {
-                // console.log(3);
                 return selector + " ." + sel;
               } else {
-                // console.log(2, sel.replace(/^ *(body|html)/, selector))
+                // HTML and Body elements cannot be contained within our container so lets extract their styles
                 return sel.trim().replace(/^[\s\S]*(body|html)/, selector);
               }
             } else {
-              // console.log(4);
               return selector + " " + sel.trim();
             }
           })

--- a/test/fixtures/leave-body-expected.css
+++ b/test/fixtures/leave-body-expected.css
@@ -1,13 +1,13 @@
 /* Ensure is left. */
-body {
+.my-container .body {
   color: red;
 }
 
-html {
+.my-container .html {
   color: red;
 }
 
 /* Ensure is prefixed. */
-p {
+.my-container p {
   color: red;
 }

--- a/test/fixtures/replacement-tags-expected.css
+++ b/test/fixtures/replacement-tags-expected.css
@@ -7,6 +7,10 @@
   color: green;
 }
 
+.my-container p, .my-container, .my-container img {
+  color: green;
+}
+
 /* Ensure their child selectors are not replaced. */
 .my-container p {
   font-style: italic;

--- a/test/fixtures/replacement-tags-raw.css
+++ b/test/fixtures/replacement-tags-raw.css
@@ -7,6 +7,12 @@ body {
   color: green;
 }
 
+p,
+body,
+img {
+  color: green;
+}
+
 /* Ensure their child selectors are not replaced. */
 html p {
   font-style: italic;

--- a/test/mainTest.js
+++ b/test/mainTest.js
@@ -9,7 +9,7 @@ describe("PostCSS Prefix Wrap", function () {
 
   // Generate a postcss instance with our plugin enabled.
   var postCSS = postcss([prefixWrap(".my-container")]);
-  var postCSSSkip = postcss([prefixWrap(".my-container", {skipRootTags: true})]);
+  var postCSSSkip = postcss([prefixWrap(".my-container", {prefixRootTags: true})]);
 
   describe("Standard Prefixing", function () {
     it("adds prefix class for tags", function () {
@@ -50,10 +50,10 @@ describe("PostCSS Prefix Wrap", function () {
     });
   });
 
-  describe("Skip html/body replacement", function () {
-    it("replaces global selectors with prefix", function () {
+  describe("Prefix html/body tags", function () {
+    it("Add prefix to global selectors", function () {
       assert.equal(
-        fs.readFileSync(__dirname + "/fixtures/leave-body.css", "UTF-8"),
+        fs.readFileSync(__dirname + "/fixtures/leave-body-expected.css", "UTF-8"),
         postCSSSkip.process(fs.readFileSync(__dirname + "/fixtures/leave-body.css", "UTF-8")).css
       );
     });


### PR DESCRIPTION
Hello again. I'm sorry, I've found a bug in my code for skipping root tags in multiline css rules.
It was unable to handle rules like
```
body,
p,
img { ... }
```
It's not widespread, but anyway it should work properly :).

So I've changed a bit. Now the option is called prefixRootTags and if it's set to `true` it transforms html and body into classes and add prefix. That's the same (it will allow to guard original html and body css attributes) and leaves current replacement functionality as is if no options are passed.

Sorry again, was in a hurry, so haven't thought about all options.