### PR TITLE
[fix] more robust @keyframes detection, preserves 'from'/'to' within @keyframes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ var postcss = require("postcss");
    * @param cssSelector
    * @returns {null|String}
    */
-  PostCSSPrefixWrap.prototype.prefixWrapCSSSelector = function (cssSelector) {
+  PostCSSPrefixWrap.prototype.prefixWrapCSSSelector = function (cssSelector, cssRule) {
     var that = this;
 
     var cleanSelector = cssSelector.replace(that.anyWhitespaceAtBeginningOrEnd, "");
@@ -38,7 +38,7 @@ var postcss = require("postcss");
       return null;
     }
 
-    if (cleanSelector.match(that.isKeyframePercentage)) {
+    if (cssRule.parent.type === "atrule" && ["keyframes", "-webkit-keyframes", "-moz-keyframes", "-o-keyframes"].indexOf(cssRule.parent.name) !== -1) {
       return cleanSelector;
     }
 
@@ -67,7 +67,7 @@ var postcss = require("postcss");
       cssRule.selector = cssRule.selector
         .split(",")
         .map(function (cssSelector) {
-          return that.prefixWrapCSSSelector(cssSelector);
+          return that.prefixWrapCSSSelector(cssSelector, cssRule);
         })
         .filter(that.invalidCSSSelectors)
         .join(", ");

--- a/test-unit/fixtures/keyframes-expected.css
+++ b/test-unit/fixtures/keyframes-expected.css
@@ -1,5 +1,9 @@
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes */
 @keyframes pulse {
-  0% {
+  from {
+    /* ... */
+  }
+  1% {
     opacity: 1;
     -webkit-transform: scale(1);
     transform: scale(1);
@@ -9,9 +13,17 @@
     -webkit-transform: scale(2);
     transform: scale(2);
   }
-  100% {
+  90%, 95% {
+    opacity: 0;
+    -webkit-transform: scale(2.5);
+    transform: scale(2.5);
+  }
+  99% {
     opacity: 0;
     -webkit-transform: scale(3);
     transform: scale(3);
+  }
+  to {
+    /* ... */   
   }
 }

--- a/test-unit/fixtures/keyframes-raw.css
+++ b/test-unit/fixtures/keyframes-raw.css
@@ -1,5 +1,9 @@
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes */
 @keyframes pulse {
-  0% {
+  from {
+    /* ... */
+  }
+  1% {
     opacity: 1;
     -webkit-transform: scale(1);
     transform: scale(1);
@@ -9,9 +13,17 @@
     -webkit-transform: scale(2);
     transform: scale(2);
   }
-  100% {
+  90%, 95% {
+    opacity: 0;
+    -webkit-transform: scale(2.5);
+    transform: scale(2.5);
+  }
+  99% {
     opacity: 0;
     -webkit-transform: scale(3);
     transform: scale(3);
+  }
+  to {
+    /* ... */   
   }
 }


### PR DESCRIPTION
Changed from detecting percentage selectors (@keyframes children) to detection of @keyframes parent element.