### PR TITLE
Added ignored selectors list

### DIFF
--- a/src/PostCSSPrefixWrap/Plugin.js
+++ b/src/PostCSSPrefixWrap/Plugin.js
@@ -14,6 +14,8 @@ class Plugin {
         ? options.prefixRootTags
         : false;
     this.prefixSelector = prefixSelector;
+    this.ignoredSelectors = options !== undefined && options.hasOwnProperty("ignoredSelectors")
+        ? options.ignoredSelectors : [];
   }
 
   static asPostCSSPlugin() {
@@ -39,6 +41,10 @@ class Plugin {
 
     // Do not prefix keyframes rules.
     if (Selector.isKeyframes(cssRule)) {
+      return cleanSelector;
+    }
+
+    if (this.ignoredSelectors.some(currentValue => cleanSelector.match(currentValue))) {
       return cleanSelector;
     }
 

--- a/src/PostCSSPrefixWrap/Plugin.js
+++ b/src/PostCSSPrefixWrap/Plugin.js
@@ -44,6 +44,7 @@ class Plugin {
       return cleanSelector;
     }
 
+    // Check for matching ignored selectors
     if (this.ignoredSelectors.some(currentValue => cleanSelector.match(currentValue))) {
       return cleanSelector;
     }

--- a/unit/fixtures/ignore-selectors-expected.css
+++ b/unit/fixtures/ignore-selectors-expected.css
@@ -1,0 +1,12 @@
+:root {
+  --main-color: hotpink;
+  --pane-padding: 5px 42px;
+}
+
+#my-id {
+  font-size: 40px;
+}
+
+.some-class {
+  color: red;
+}

--- a/unit/fixtures/ignore-selectors.css
+++ b/unit/fixtures/ignore-selectors.css
@@ -1,0 +1,12 @@
+:root {
+  --main-color: hotpink;
+  --pane-padding: 5px 42px;
+}
+
+#my-id {
+  font-size: 40px;
+}
+
+.some-class {
+  color: red;
+}

--- a/unit/mainTest.js
+++ b/unit/mainTest.js
@@ -9,6 +9,11 @@ describe("PostCSS Prefix Wrap", () => {
   const postCSSSkip = PostCSS([
     PrefixWrap(".my-container", { prefixRootTags: true })
   ]);
+  const postCSSIgnore = PostCSS([
+    PrefixWrap(".my-container", {
+      ignoredSelectors: [":root", "#my-id", /^\.some-(.+)$/]
+    })
+  ]);
   const fixtures = __dirname + "/fixtures";
 
   describe("Standard Prefixing", () => {
@@ -65,7 +70,7 @@ describe("PostCSS Prefix Wrap", () => {
     });
   });
 
-  describe("Leave Our Container", () => {
+  describe("Root", () => {
     it("leaves selectors that contain our selector in the left most location", () => {
       PrefixAssert.actualMatchesExpectedAfterPrefixWrap(
         postCSS,
@@ -91,6 +96,16 @@ describe("PostCSS Prefix Wrap", () => {
         postCSS,
         fixtures + "/keyframes-raw.css",
         fixtures + "/keyframes-expected.css"
+      );
+    });
+  });
+
+  describe("Ignored Selectors", () => {
+    it("ignores selectors that are in a ignore list", () => {
+      PrefixAssert.actualMatchesExpectedAfterPrefixWrap(
+        postCSSIgnore,
+        fixtures + "/ignore-selectors.css",
+        fixtures + "/ignore-selectors-expected.css"
       );
     });
   });

--- a/unit/mainTest.js
+++ b/unit/mainTest.js
@@ -70,7 +70,7 @@ describe("PostCSS Prefix Wrap", () => {
     });
   });
 
-  describe("Root", () => {
+  describe("Leave Our Container", () => {
     it("leaves selectors that contain our selector in the left most location", () => {
       PrefixAssert.actualMatchesExpectedAfterPrefixWrap(
         postCSS,


### PR DESCRIPTION
Problem:

There are selectors like `:root` or any else who bind on body. Those selectors should not wrapping.

Solving:

I added option `ignoredSelectors`. It's array with selectors or regexps.