### PR TITLE
feature(plugin): Allow an optional file whitelist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ PrefixWrap(".my-container", {
 
 ### File Whitelist
 
-In certain scenarios, you may only want `PrefixWrap()` to wrap specific CSS file(s). This is done using the `whitelist` option.
+In certain scenarios, you may only want `PrefixWrap()` to wrap certain CSS file(s). This is done using the `whitelist` option.
 
 ```javascript
 PrefixWrap(".my-custom-wrap", {
-    whitelist: ['editor.css']
+    whitelist: ["editor.css"]
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ PrefixWrap(".my-container", {
 });
 ```
 
+### File Whitelist
+
+In certain scenarios, you may only want `PrefixWrap()` to wrap specific CSS file(s). This is done using the `whitelist` option.
+
+```javascript
+PrefixWrap(".my-custom-wrap", {
+    whitelist: ['editor.css']
+});
+```
+
 ## Want to lean more?
 
 -   See our [Contributing Guide](CONTRIBUTING.md) for details on how this repository is developed.

--- a/src/OurPlugin.ts
+++ b/src/OurPlugin.ts
@@ -13,12 +13,14 @@ export default class OurPlugin {
   private prefixRootTags: boolean;
   private isPrefixSelector: RegExp;
   private prefixSelector: string;
+  private whitelist: Array<string>;
 
   constructor(prefixSelector: string, options = {}) {
     this.ignoredSelectors = Hash.value(options, "ignoredSelectors", []);
     this.prefixRootTags = Hash.value(options, "prefixRootTags", false);
     this.isPrefixSelector = new RegExp(`^s*${prefixSelector}.*$`);
     this.prefixSelector = prefixSelector;
+    this.whitelist = Hash.value(options, "whitelist", []);
   }
 
   static asPostCSSPlugin(): PostCSS.Plugin<string> {
@@ -87,9 +89,11 @@ export default class OurPlugin {
 
   prefix(): Function {
     return (css: Rule) => {
-      css.walkRules((cssRule: Rule) => {
-        this.prefixWrapCSSRule(cssRule);
-      });
+      if (! this.whitelist.length || css.source.input.file.includes(this.whitelist)) {
+        css.walkRules((cssRule: Rule) => {
+          this.prefixWrapCSSRule(cssRule);
+        });
+      }
     };
   }
 }

--- a/src/OurPlugin.ts
+++ b/src/OurPlugin.ts
@@ -6,14 +6,15 @@ import Hash from "./Hash";
 interface OurPluginOptions {
   ignoredSelectors?: Array<string>;
   prefixRootTags?: boolean;
+  whitelist?: Array<string>;
 }
 
 export default class OurPlugin {
   private ignoredSelectors: Array<string>;
   private prefixRootTags: boolean;
+  private whitelist: Array<string>;
   private isPrefixSelector: RegExp;
   private prefixSelector: string;
-  private whitelist: Array<string>;
 
   constructor(prefixSelector: string, options = {}) {
     this.ignoredSelectors = Hash.value(options, "ignoredSelectors", []);
@@ -89,7 +90,12 @@ export default class OurPlugin {
 
   prefix(): Function {
     return (css: Rule) => {
-      if (!this.whitelist.length || css.source.input.file.includes(this.whitelist)) {
+      if (
+        !this.whitelist.length ||
+        this.whitelist.some(currentValue =>
+          css.source?.input.file?.match(currentValue)
+        )
+      ) {
         css.walkRules((cssRule: Rule) => {
           this.prefixWrapCSSRule(cssRule);
         });

--- a/src/OurPlugin.ts
+++ b/src/OurPlugin.ts
@@ -19,9 +19,9 @@ export default class OurPlugin {
   constructor(prefixSelector: string, options = {}) {
     this.ignoredSelectors = Hash.value(options, "ignoredSelectors", []);
     this.prefixRootTags = Hash.value(options, "prefixRootTags", false);
+    this.whitelist = Hash.value(options, "whitelist", []);
     this.isPrefixSelector = new RegExp(`^s*${prefixSelector}.*$`);
     this.prefixSelector = prefixSelector;
-    this.whitelist = Hash.value(options, "whitelist", []);
   }
 
   static asPostCSSPlugin(): PostCSS.Plugin<string> {

--- a/src/OurPlugin.ts
+++ b/src/OurPlugin.ts
@@ -89,7 +89,7 @@ export default class OurPlugin {
 
   prefix(): Function {
     return (css: Rule) => {
-      if (! this.whitelist.length || css.source.input.file.includes(this.whitelist)) {
+      if (!this.whitelist.length || css.source.input.file.includes(this.whitelist)) {
         css.walkRules((cssRule: Rule) => {
           this.prefixWrapCSSRule(cssRule);
         });


### PR DESCRIPTION
This allows for an optional whitelist as to not wrap every CSS file being processed by webpack. I wasn't sure how to go about tests for it so they are currently not included.

**Edit**: Will fix linting tests momentarily, have to run for a few.