### PR TITLE
Clarify prefixRootTags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ PrefixWrap(".my-container", {
 });
 ```
 
+With this option, a selector like `html` will be converted to `.my-container .html`, rather than the default `.my-container`.
+
 ### File Whitelist
 
 In certain scenarios, you may only want `PrefixWrap()` to wrap certain CSS files. This is done using the `whitelist` option.


### PR DESCRIPTION
Add an example for how root tags behave with and without this option.

---

In our team, we were unfortunately rather confused by this option, expecting it to toggle between “don’t prefix root tags” (`html`) and “prefix root tags like everything else” (`.my-container html`) – rather than the real behavior, which is to toggle between “replace root tags with the prefix” (`.my-container`) and “prefix root tags with `.` to turn them into class selectors and them prefix them like everything else” (`.my-container .html`). Maybe this can help to avoid similar confusion in others.