### PR TITLE
Escape prefixSelector

### DIFF
--- a/src/PostCSSPrefixWrap.ts
+++ b/src/PostCSSPrefixWrap.ts
@@ -23,8 +23,11 @@ export default class PostCSSPrefixWrap {
   constructor(prefixSelector: string, options: PostCSSPrefixWrapOptions = {}) {
     this.blacklist = options.blacklist ?? [];
     this.ignoredSelectors = options.ignoredSelectors ?? [];
+ 
+    const escaped = prefixSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    
     // eslint-disable-next-line security-node/non-literal-reg-expr
-    this.isPrefixSelector = new RegExp(`^${prefixSelector}$`);
+    this.isPrefixSelector = new RegExp(`^${escaped}$`);
     this.prefixRootTags = options.prefixRootTags ?? false;
     this.prefixSelector = prefixSelector;
     this.whitelist = options.whitelist ?? [];


### PR DESCRIPTION
This allows the use of prefix selectors with special chars like _.my-custom-selector[id^=my-id-starts-with-]_ and so on